### PR TITLE
Add buffering methods

### DIFF
--- a/src/PowerForensicsCore/src/PowerForensics.FileSystems.Ntfs/FileRecord.cs
+++ b/src/PowerForensicsCore/src/PowerForensics.FileSystems.Ntfs/FileRecord.cs
@@ -670,8 +670,7 @@ namespace PowerForensics.FileSystems.Ntfs
         public static IEnumerable<byte[]> GetContentBytesBuffered(string path)
         {
             FileRecord record = Get(path, true);
-            foreach (var block in record.GetContentBuffered(""))
-                yield return block;
+            return record.GetContentBuffered("");
         }
         
         private static void ApplyFixup(ref byte[] bytes, int BytesPerFileRecord)
@@ -774,11 +773,7 @@ namespace PowerForensics.FileSystems.Ntfs
                 if (attr.Name == FileRecordAttribute.ATTR_TYPE.DATA)
                 {
                     if (attr.NameString == StreamName)
-                    {
-                        foreach (var block in GetContentBuffered(attr))
-                            yield return block;
-                        yield break;
-                    }
+                        return GetContentBuffered(attr);
                 }
             }
             throw new Exception("Could not locate desired stream");
@@ -833,10 +828,7 @@ namespace PowerForensics.FileSystems.Ntfs
         {
             if (attribute.NonResident)
             {
-                foreach (var block in (attribute as NonResident).GetBytesBuffered())
-                    yield return block;
-
-                yield break;
+                return (attribute as NonResident).GetBytesBuffered();
             }
             else
             {


### PR DESCRIPTION
This PR introduces a new method `GetContentBytesBuffered` to support files bigger than 2GB which crash the original implementation.

The new method produces the same results as the original one for files <2GB.

For files >2GB the new method does not crash, however, there is still a problem: __Big files are not read completely__.

The line
```csharp
foreach (DataRun dr in this.DataRun)
```
does not iterate over the full file when the file is too big. The `DataRun` field is populated in `FileRecordAttribute.cs` like

```csharp
DataRun = Ntfs.DataRun.GetInstances(bytes, offset, volume);
```

In the `GetInstances` method we have variables like
```csharp
                int DataRunLengthByteCount = bytes[i] & 0x0F;
                int DataRunOffsetByteCount = ((bytes[i] & 0xF0) >> 4);
```
maximum integer in C# is `2,147,483,647` (2 GiB).

__Hyptothesis:__ We probably run into an overflow somewhere along these lines. 

Changing the datatype is not trivial due to dependencies in subsequent methods.